### PR TITLE
Unbreak audio build on DragonFly

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,7 @@ mod platform {
         "which audio device to record from. list devices with `pactl list short sources`";
     pub const DEFAULT_AUDIO_BACKEND: &str = "pulse";
 }
-#[cfg(target_os = "freebsd")]
+#[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
 mod platform {
     pub const DEFAULT_AUDIO_CAPTURE_DEVICE: &str = "/dev/dsp";
     pub const AUDIO_DEVICE_HELP: &str =

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,7 +85,7 @@ mod platform {
 mod platform {
     pub const DEFAULT_AUDIO_CAPTURE_DEVICE: &str = "/dev/dsp";
     pub const AUDIO_DEVICE_HELP: &str =
-        "which audio device to record from. list devices with `ossinfo -a`";
+        "which audio device to record from. list devices with `cat /dev/sndstat` (pcmN -> dspN)"
     pub const DEFAULT_AUDIO_BACKEND: &str = "oss";
 }
 use platform::*;


### PR DESCRIPTION
DragonFly supports wlroots and has fork of FreeBSD Ports, so may inherit wl-screenrec package recipe. Currently, not listed platforms fail to build:
```rust
error[E0432]: unresolved imports `platform`, `crate::Args`
  --> src/main.rs:91:5
   |
91 | use platform::*;
   |     ^^^^^^^^ use of undeclared crate or module `platform`
   |
  ::: src/audio.rs:22:30
   |
22 | use crate::{fifo::AudioFifo, Args};
   |                              ^^^^

error[E0425]: cannot find value `DEFAULT_AUDIO_CAPTURE_DEVICE` in this scope
   --> src/main.rs:163:36
    |
163 |     #[clap(long, default_value_t = DEFAULT_AUDIO_CAPTURE_DEVICE.to_string(), help = AUDIO_DEVICE_HELP)]
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope

error[E0425]: cannot find value `AUDIO_DEVICE_HELP` in this scope
   --> src/main.rs:163:85
    |
163 |     #[clap(long, default_value_t = DEFAULT_AUDIO_CAPTURE_DEVICE.to_string(), help = AUDIO_DEVICE_HELP)]
    |                                                                                     ^^^^^^^^^^^^^^^^^ not found in this scope

error[E0425]: cannot find value `DEFAULT_AUDIO_BACKEND` in this scope
   --> src/main.rs:166:36
    |
166 |     #[clap(long, default_value_t = DEFAULT_AUDIO_BACKEND.to_string(), help = "which ffmpeg audio capture backend (see https://ff...
    |                                    ^^^^^^^^^^^^^^^^^^^^^ not found in this scope

error[E0425]: cannot find value `DEFAULT_AUDIO_BACKEND` in this scope
    --> src/main.rs:1587:45
     |
1587 |     if !args.audio && args.audio_backend != DEFAULT_AUDIO_BACKEND {
     |                                             ^^^^^^^^^^^^^^^^^^^^^ not found in this scope

error[E0425]: cannot find value `DEFAULT_AUDIO_CAPTURE_DEVICE` in this scope
    --> src/main.rs:1590:44
     |
1590 |     if !args.audio && args.audio_device != DEFAULT_AUDIO_CAPTURE_DEVICE {
     |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
```

Note, `pulse` can be made as a fallback but none of BSDs have FFmpeg built with PulseAudio enabled by default. Worse, PulseAudio is [broken on DragonFly](https://github.com/DragonFlyBSD/DeltaPorts/commit/b88835f255a5) and discouraged on OpenBSD.
