### PR TITLE
remove requirement for wlr-output-management-unstable-v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Open an issue if something is not working, I'm happy to take a look.
 # System Requirements
 
 * wayland compositor supporting the following unstable protocols:
-  * [`wlr-output-management-unstable-v1`](https://wayland.app/protocols/wlr-output-management-unstable-v1) 
   * [`wlr-screencopy-unstable-v1`](https://wayland.app/protocols/wlr-screencopy-unstable-v1)
 
    [Sway](https://swaywm.org/), [Hyprland](https://hyprland.org/), and [wayfire](https://wayfire.org/) all meet this criteria.

--- a/src/main.rs
+++ b/src/main.rs
@@ -535,7 +535,7 @@ struct State<S: CaptureSource> {
 
 struct OutputProbeState {
     partial_outputs: HashMap<TypedObjectId<WlOutput>, PartialOutputInfo>, // key is xdg-output name (wayland object ID)
-    outputs: HashMap<TypedObjectId<WlOutput>, Option<OutputInfo>>, // none for disabled
+    outputs: HashMap<TypedObjectId<WlOutput>, Option<OutputInfo>>,        // none for disabled
 }
 
 enum EncConstructionStage<S> {
@@ -746,7 +746,6 @@ impl<S: CaptureSource + 'static> State<S> {
             .bind(&eq, 3..=ZxdgOutputManagerV1::interface().version, ())
             .context("your compositor does not support zxdg-output-manager and therefore is not support by wl-screenrec. See the README for supported compositors")?;
 
-
         let mut partial_outputs = HashMap::new();
         for g in gm.contents().clone_list() {
             if g.interface == WlOutput::interface().name {
@@ -900,7 +899,6 @@ impl<S: CaptureSource + 'static> State<S> {
 
         self.start_if_output_probe_complete(qhandle);
     }
-
 
     fn start_if_output_probe_complete(&mut self, qhandle: &QueueHandle<Self>) {
         let p = if let EncConstructionStage::ProbingOutputs(p) = &self.enc {


### PR DESCRIPTION
I used it to get fractional scale before, but you can just get fractional scale by comparing logical & pixel sizes of displays
