### PR TITLE
Retry on failed frame captures, and update ext_image_copy_capture_session_v1 buffer parameters on every ::done

### DIFF
--- a/src/cap_ext_image_copy.rs
+++ b/src/cap_ext_image_copy.rs
@@ -162,7 +162,9 @@ impl Dispatch<ExtImageCopyCaptureFrameV1, ()> for State<CapExtImageCopy> {
                 let (hi, lo, n) = state.enc.unwrap().cap.time.take().unwrap();
                 state.on_copy_complete(qhandle, hi, lo, n);
             }
-            Failed { .. } => todo!(),
+            Failed { .. } => {
+                state.on_copy_fail(qhandle);
+            }
             _ => {}
         }
     }


### PR DESCRIPTION
I recently tried to use `wl-screenrec --experiemental-ext-image-copy-capture` with wlroots' draft implementation of ext-image-copy-capture, but that produced an error described at https://github.com/russelltg/wl-screenrec/issues/101, when I resized the output while a full-output recording was running. (By running Sway inside itself, and resizing the nested Sway window.) This is admittedly a weird thing to do, but it is an easy way to test that programs can reliably handle runtime output changes (like changing output scale or mode), that sometimes reveals race conditions.

After doing a quick fix for #101 (see last commit of https://github.com/mstoeckl/wl-screenrec/tree/fix-duplicate-frame-hack, which is probably not the best way to solve the problem), I made other patches to address minor issues that I noticed, which I am submitting in this PR.

* Retry instead of quitting when copying a frame fails for an unknown reason, because when resizing the output compositors sometimes make the frame collection fail (e.g., because it was resized again after the ::frame request was made)
* Update the buffer constraints (size and chosen format) every time ext_image_copy_capture_session_v1::done is received, instead of just the first time, so later frame requests use the new parameters.

