### PR TITLE
feat: add script to get supported compositors for `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,21 @@ Open an issue if something is not working, I'm happy to take a look.
 
 # System Requirements
 
-* wayland compositor supporting the following protocols:
+* Wayland compositor supporting the following protocols:
   * [`wlr-screencopy-unstable-v1`](https://wayland.app/protocols/wlr-screencopy-unstable-v1)
   * [`linux-dmabuf-v1`](https://wayland.app/protocols/linux-dmabuf-v1)
   * [`xdg-output-unstable-v1`](https://wayland.app/protocols/xdg-output-unstable-v1)
+    These compositors all meet this criteria:
+    <!-- Generated using `./compatible-compositors.nu` -->
+    | compositor                                          | version  |
+    | --------------------------------------------------- | -------- |
+    | [Hyprland](https://hyprland.org/)                   | `0.42.0` |
+    | [Jay](https://github.com/mahkoh/jay)                | `1.7.0`  |
+    | [Mir](https://github.com/canonical/mir)             | `2.19`   |
+    | [niri](https://github.com/YaLTeR/niri)              | `25.01`  |
+    | [Sway](https://swaywm.org/)                         | `1.10`   |
+    | [Treeland](https://github.com/linuxdeepin/treeland) | `0.5.17` |
 
-   [Sway](https://swaywm.org/), [Hyprland](https://hyprland.org/), and [Wayfire](https://wayfire.org/) all meet this criteria.
 * [`vaapi`](https://01.org/temp-linuxgraphics/community/vaapi) encode support, consult your distribution for how to set this up. Known good configurations:
   * Intel iGPUs
   * Radeon GPUs
@@ -99,7 +108,7 @@ wl-screenrec -g "0,0 128x128" # manual region
 Capture 444 video (no pixel format compression):
 
 > NOTE: Look at `vainfo -a` to see your supported pixel formats. Support is very
-> hardware-dependent. For example, on my machine only HEVC suports 444 formats, and
+> hardware-dependent. For example, on my machine only HEVC supports 444 formats, and
 > all of 8-bit RGB formats didn't work for whatever reason.
 
 ```bash

--- a/compatible-compositors.nu
+++ b/compatible-compositors.nu
@@ -1,0 +1,46 @@
+#!/usr/bin/env nu
+
+let protocols = [[name, url];
+	["linux-dmabuf-v1" "https://wayland.app/protocols/linux-dmabuf-v1"]
+	["wlr-screencopy-unstable-v1" "https://wayland.app/protocols/wlr-screencopy-unstable-v1"]
+	["xdg-output-unstable-v1" "https://wayland.app/protocols/xdg-output-unstable-v1"]
+]
+
+let known_compositors = {
+	Mutter: "https://mutter.gnome.org/"
+	KWin: "https://kde.org/plasma-desktop/"
+	Sway: "https://swaywm.org/"
+	COSMIC: "https://system76.com/cosmic/"
+	Hyprland: "https://hyprland.org/"
+	niri: "https://github.com/YaLTeR/niri"
+	Weston: "https://wayland.pages.freedesktop.org/weston/"
+	Mir: "https://github.com/canonical/mir"
+	GameScope: "https://github.com/ValveSoftware/gamescope"
+	Jay: "https://github.com/mahkoh/jay"
+	Treeland: "https://github.com/linuxdeepin/treeland"
+}
+
+$protocols | par-each {|protocol| 
+	let html = http get $protocol.url
+
+	let compositors: table<compositor: string, version: string> = $html
+		| query web --query "h4#compositor-support + div table th:nth-child(n + 2)"
+		| each { |pair| {compositor: ($pair | get 0) version: ($pair | get 1) } }
+
+	let supported: list<bool> = $html
+		| query web --query "h4#compositor-support + div table tbody td:nth-child(n + 2)"
+		| flatten
+		| each { if $in == "x" { false } else { true } }
+
+	$compositors | merge ($supported | wrap $protocol.name)
+}
+| reduce {|it, acc| $it | join $acc compositor } | reject version_ | reject version_
+| insert supported {|row|
+	$protocols.name | each { |protocol| $row | get $protocol } | all { $in }
+}
+| where supported
+| select compositor version
+| sort-by compositor --ignore-case
+| update compositor { |row| $"[($row.compositor)]\(($known_compositors | get $row.compositor )\)" }
+| update version { $"`($in)`" }
+| to md --pretty


### PR DESCRIPTION
This PR adds a [nushell](https://www.nushell.sh/) `./compatible-compositors.nu` script to auto-generate the list of compatible compositors in README.md. It queries Wayland Explorer and scrapes the html to find all the compositors which support the needed protocols. It then outputs the result a s a pretty formatted Markdown table that you can paste straight into README.md.

I originally wanted to see if the compositor I use currently, niri, was supported and got a bit carried away trying to automate the check :grin:

Feel free to ignore the script if you are not familiar with Nushell or do not wanna maintain it.