### PR TITLE
Add option to toggle mouse pointer capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ Usage: wl-screenrec [OPTIONS]
 Options:
       --no-hw
           don't use the GPU encoder, download the frames onto the CPU and use a software encoder. Ignored if `encoder` is supplied
+      --no-cursor
+          don't capture the cursor
   -f, --filename <FILENAME>
           filename to write to. container type is detected from extension [default: screenrecord.mp4]
   -g, --geometry <GEOMETRY>

--- a/src/cap_wlr_screencopy.rs
+++ b/src/cap_wlr_screencopy.rs
@@ -98,7 +98,7 @@ impl Dispatch<ZwpLinuxDmabufFeedbackV1, ()> for State<CapWlrScreencopy> {
                 .node_with_type(drm::node::NodeType::Render)
                 .unwrap()
                 .unwrap();
-
+            state.enc.unwrap_cap().cap_cursor = state.args.cap_cursor;
             let path = node.dev_path().unwrap();
             state.enc.unwrap_cap().drm_device = Some(path);
         }
@@ -109,6 +109,7 @@ pub struct CapWlrScreencopy {
     screencopy_manager: ZwlrScreencopyManagerV1,
     output: WlOutput,
     drm_device: Option<PathBuf>,
+    cap_cursor: bool,
 }
 impl CaptureSource for CapWlrScreencopy {
     fn new(
@@ -128,6 +129,7 @@ impl CaptureSource for CapWlrScreencopy {
             screencopy_manager: man,
             output,
             drm_device: None,
+            cap_cursor: false,
         })
     }
 
@@ -142,9 +144,9 @@ impl CaptureSource for CapWlrScreencopy {
     fn alloc_frame(&self, eq: &QueueHandle<State<Self>>) -> Option<Self::Frame> {
         // creating this triggers the linux_dmabuf event, which is where we allocate etc
 
-        let _capture = self
-            .screencopy_manager
-            .capture_output(1, &self.output, eq, ());
+        let _capture =
+            self.screencopy_manager
+                .capture_output(self.cap_cursor.into(), &self.output, eq, ());
 
         None
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,6 +102,9 @@ pub struct Args {
     #[clap(long="no-hw", default_value = "true", action=ArgAction::SetFalse, help="don't use the GPU encoder, download the frames onto the CPU and use a software encoder. Ignored if `encoder` is supplied")]
     hw: bool,
 
+    #[clap(long="no-cursor", default_value = "true", action=ArgAction::SetFalse, help="don't capture the cursor")]
+    cap_cursor: bool,
+
     #[clap(
         long,
         short,


### PR DESCRIPTION
This PR adds an option to control whether the mouse pointer is captured during screen recording.

- A new CLI flag `--no-cursor` is introduced
- By default, the pointer is still captured to preserve existing behavior

This feature can be useful for users who want cleaner recordings without the cursor.

Tested on: archlinux + Hyprland

Let me know if anything needs to be adjusted!
