### PR TITLE
add --capture-source flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,8 +191,8 @@ Options:
           GOP (group of pictures) size
       --generate-completions <COMPLETIONS_GENERATOR>
           print completions for the specified shell to stdout [possible values: bash, elvish, fish, powershell, zsh]
-      --experimental-ext-image-copy-capture
-          use the new ext-image-copy-capture protocol
+      --capture-backend <CAPTURE_BACKEND>
+          which capture backend to use [default: auto] [possible values: auto, wlr-screencopy, ext-image-copy-capture]
   -h, --help
           Print help
   -V, --version

--- a/src/cap_ext_image_copy.rs
+++ b/src/cap_ext_image_copy.rs
@@ -136,7 +136,7 @@ impl Dispatch<ExtImageCopyCaptureFrameV1, ()> for State<CapExtImageCopy> {
     ) {
         use wayland_protocols::ext::image_copy_capture::v1::client::ext_image_copy_capture_frame_v1::Event;
         match event {
-            Event::Transform { .. } => {}, // TODO: implement dynamic transform
+            Event::Transform { .. } => {} // TODO: implement dynamic transform
             Event::Damage { .. } => {}
             Event::PresentationTime {
                 tv_sec_hi,


### PR DESCRIPTION
this removes the --experimental-ext-image-copy-capture flag, and adds auto detection logic.

it prefers ext-image-copy-capture when available, as it replaces the wlr capture protocol
