### PR TITLE
#122: use event loop so signals are handled immediately

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,6 +419,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "mio"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -626,6 +638,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-mio"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -747,6 +770,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wayland-backend"
@@ -997,9 +1026,11 @@ dependencies = [
  "libc",
  "log",
  "log-once",
+ "mio",
  "nix",
  "serde_json",
  "signal-hook",
+ "signal-hook-mio",
  "simplelog",
  "thiserror",
  "wayland-backend",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ ffmpeg-next = "7.0.1"
 ffmpeg-sys-next = "7.0.0" # need direct dep on -sys to get metadata to consume in build.rs
 thiserror = "2.0.3"
 human-size = "0.4.2"
-signal-hook = "0.3.15"
 anyhow = "1.0.71"
 libc = "0.2.147"
 simplelog = "0.12.1"
@@ -40,6 +39,9 @@ clap_complete = "4.5.8"
 log-once = "0.4.1"
 drm = "0.14.0"
 ash = { version = "0.38.0", optional = true }
+mio = { version = "1.0.4", features = ["os-poll"] }
+signal-hook = "0.3.15"
+signal-hook-mio = { version = "0.2.4", features = ["support-v1_0"] }
 
 [patch.crates-io]
 # Waiting on https://github.com/zmwangx/rust-ffmpeg-sys/pull/91


### PR DESCRIPTION
Fixes #122 

I prefer event loops (lighter, don't have to worry about asynchronous behavior, don't have to worry about cancellation to get ownership of &mut state back) so I went that direction. 