### PR TITLE
bug: Adjust encoder frame rate based on max_fps(/src/main.rs)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1647,7 +1647,14 @@ fn make_video_params(
     enc.set_width(encode_w as u32);
     enc.set_height(encode_h as u32);
     enc.set_time_base(Rational(1, 1_000_000_000));
-    enc.set_frame_rate(Some(framerate));
+
+    let encoder_framerate = if let Some(max_fps) = args.max_fps {
+        Rational(max_fps as i32, 1)
+    } else {
+        framerate
+    };
+    enc.set_frame_rate(Some(encoder_framerate));
+    
     if let Some(gop) = args.gop_size {
         enc.set_gop(gop);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1649,13 +1649,8 @@ fn make_video_params(
     enc.set_time_base(Rational(1, 1_000_000_000));
 
     let encoder_framerate = if let Some(max_fps) = args.max_fps {
-        let scaled = max_fps * 1000.0;
-        let numerator = scaled as i32;
-        let max_fps_rational = Rational(numerator, 1000);
-        let framerate_value = framerate.numerator() as f64 / framerate.denominator() as f64;
-        let max_fps_value = max_fps_rational.numerator() as f64 / max_fps_rational.denominator() as f64;
-        
-        if max_fps_value < framerate_value {
+        let max_fps_rational = Rational::from(max_fps);
+        if max_fps_rational < framerate {
             max_fps_rational
         } else {
             framerate

--- a/src/main.rs
+++ b/src/main.rs
@@ -1649,7 +1649,17 @@ fn make_video_params(
     enc.set_time_base(Rational(1, 1_000_000_000));
 
     let encoder_framerate = if let Some(max_fps) = args.max_fps {
-        Rational(max_fps as i32, 1)
+        let scaled = max_fps * 1000.0;
+        let numerator = scaled as i32;
+        let max_fps_rational = Rational(numerator, 1000);
+        let framerate_value = framerate.numerator() as f64 / framerate.denominator() as f64;
+        let max_fps_value = max_fps_rational.numerator() as f64 / max_fps_rational.denominator() as f64;
+        
+        if max_fps_value < framerate_value {
+            max_fps_rational
+        } else {
+            framerate
+        }
     } else {
         framerate
     };


### PR DESCRIPTION
Set encoder frame rate based on max_fps argument if provided.

Problem: The video encoder always uses the display refresh rate as its own framerate, while the `--max_fps` argument only reduces the number of frames sent to the encoder. This mismatch results in blurry frames, particularly when the `--max_fps` is significantly lower than the display refresh rate.

Tested on: fedora43 linux + sway

Let me know if anything needs to be adjusted.